### PR TITLE
[Feat] 공용 컴포넌트 구현

### DIFF
--- a/mohaemukzip/Resources/Fonts/Fonts.swift
+++ b/mohaemukzip/Resources/Fonts/Fonts.swift
@@ -37,7 +37,7 @@ extension Font {
         return pretend(type: .bold, size: 26)
     }
     
-    static var PretendardBod24: Font {
+    static var PretendardBold24: Font {
         return pretend(type: .bold, size: 24)
     }
     

--- a/mohaemukzip/Sources/Common/Components/Buttons/OrangeButton.swift
+++ b/mohaemukzip/Sources/Common/Components/Buttons/OrangeButton.swift
@@ -1,0 +1,48 @@
+//
+//  Button.swift
+//  mohaemukzip
+//
+//  Created by 이한결 on 1/15/26.
+//
+
+import SwiftUI
+
+enum type {
+    case big
+    case small
+}
+
+struct OrangeButton: View {
+    let text: String
+    let type: type
+    
+    var body: some View {
+        switch type {
+        case .big:
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .foregroundStyle(.main400)
+                    .frame(width: 359, height: 57)
+                Text(text)
+                    .foregroundStyle(.white)
+                    .font(.PretendardSemibold18)
+            }
+        case .small:
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .foregroundStyle(.main400)
+                    .frame(width: 150, height: 46)
+                Text(text)
+                    .foregroundStyle(.white)
+                    .font(.PretendardSemibold16)
+            }
+        } // end of switch
+        
+    } // end of body
+}
+
+#Preview {
+    OrangeButton(text: "시작하기", type: .small)
+}
+
+/// OrangeButton(text: "버튼 안에 넣을 텍스트", type: .big 아니면 .small)

--- a/mohaemukzip/Sources/Common/Components/IngredientDetailCard/IngredientDetailCard.swift
+++ b/mohaemukzip/Sources/Common/Components/IngredientDetailCard/IngredientDetailCard.swift
@@ -1,0 +1,37 @@
+//
+//  IngredientDetailCard.swift
+//  mohaemukzip
+//
+//  Created by 이한결 on 1/15/26.
+//
+
+import SwiftUI
+
+struct IngredientDetailCard: View {
+    let ingredientInfo: IngredientDetailCardModel
+    
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .foregroundStyle(.grey50)
+                .frame(width: 76, height: 72)
+            VStack {
+                Text(ingredientInfo.name)
+                    .font(.PretendardMedium13)
+                    .foregroundStyle(.grey900)
+                Spacer().frame(height: 4)
+                Text(ingredientInfo.amount)
+                    .font(.PretendardRegular13)
+                    .foregroundStyle(.grey600)
+                Text("(\(ingredientInfo.nnng))")
+                    .font(.PretendardRegular13)
+                    .foregroundStyle(.grey600)
+            }
+        }
+    }
+    
+}
+
+#Preview {
+    IngredientDetailCard(ingredientInfo: IngredientDetailCardModel(name: "양배추", amount: "100g", nnng: "nnng"))
+}

--- a/mohaemukzip/Sources/Common/Components/IngredientDetailCard/IngredientDetailCardModel.swift
+++ b/mohaemukzip/Sources/Common/Components/IngredientDetailCard/IngredientDetailCardModel.swift
@@ -1,0 +1,15 @@
+//
+//  IngredientDetailCardModel.swift
+//  mohaemukzip
+//
+//  Created by 이한결 on 1/15/26.
+//
+
+import Foundation
+
+struct IngredientDetailCardModel: Identifiable, Hashable {
+    let id: UUID = UUID()
+    let name: String
+    let amount: String
+    let nnng: String
+}

--- a/mohaemukzip/Sources/Common/Components/IngredientManagementCard/IngredientManagementCard.swift
+++ b/mohaemukzip/Sources/Common/Components/IngredientManagementCard/IngredientManagementCard.swift
@@ -1,0 +1,47 @@
+//
+//  IngredientCard.swift
+//  mohaemukzip
+//
+//  Created by 이한결 on 1/15/26.
+//
+
+import SwiftUI
+
+struct IngredientManagementCard: View {
+    let ingredientInfo: IngredientManagementCardModel
+    let color: Color // MARK: viewModel에서 소비기한 계산해서 color 넘겨줄 것
+    
+        
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .foregroundStyle(.grey50)
+                .frame(width: 76, height: 80)
+            VStack {
+                Text(ingredientInfo.name)
+                    .font(.PretendardMedium13)
+                    .foregroundStyle(.grey900)
+                Spacer().frame(height: 4)
+                Text(ingredientInfo.amount)
+                    .font(.PretendardMedium13)
+                    .foregroundStyle(.grey600)
+                Spacer().frame(height: 6)
+                ZStack {
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(color.opacity(0.5), lineWidth: 1)
+                        .foregroundStyle(Color.clear)
+                        .frame(width: 44, height: 18)
+                    
+                    Text("D-\(ingredientInfo.expirationData)")
+                        .font(.PretendardMedium13)
+                        .foregroundStyle(color)
+                }
+            }
+        }
+
+    } // end of body
+}
+
+#Preview {
+    IngredientManagementCard(ingredientInfo: IngredientManagementCardModel(name: "배추", amount: "100g", expirationData: 100), color: .green)
+}

--- a/mohaemukzip/Sources/Common/Components/IngredientManagementCard/IngredientManagementCardModel.swift
+++ b/mohaemukzip/Sources/Common/Components/IngredientManagementCard/IngredientManagementCardModel.swift
@@ -1,0 +1,16 @@
+//
+//  IngredientCardModel.swift
+//  mohaemukzip
+//
+//  Created by 이한결 on 1/15/26.
+//
+
+import Foundation
+
+struct IngredientManagementCardModel: Identifiable, Hashable {
+    // MARK: API 연결 시 삭제하고 백에서 주는 고유 id 사용할 것 (백에서 만약 고유 id 준다면!)
+    let id: UUID = UUID()
+    let name: String
+    let amount: String
+    let expirationData: Int
+}

--- a/mohaemukzip/mohaemukzipApp.swift
+++ b/mohaemukzip/mohaemukzipApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct mohaemukzipApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainTabView()
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형 Feat

어떤 변경 사항이 있나요?

- [x] 재료 탭 컴포넌트 구현
- [x] big, small 버튼 구현 


## 🛠️ 작업내용
[ 자주 쓰일 혹은 공용으로 쓰일 컴포넌트 구현, 컴포넌트 코드에는 순수 UI 작업만 하였고 Button으로 사용할 경우에는 해당 뷰 코드에서 따로 Button을 만들어서 그 안에 넣어서 사용하세요! ]

## 📱 스크린샷
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/15e7ef51-fc7f-4d4d-842e-47cafb99bad0" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/2b09f69f-7c83-43a0-b9b7-a2969dd1166a" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/5d10c63e-90bb-4de1-9a92-afc95478abe3" />

|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## 📌 리뷰 포인트
[ 작명센스가 꽝이라 죄송합니다! 좋은 컴포넌트 이름 아이디어 추천 받습니다..! ]

## 관련 이슈
- Resolved: #12 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 폰트 이름 수정: PretendardBod24를 PretendardBold24로 변경하여 명명 규칙 개선

* **새로운 기능**
  * 다양한 크기의 오렌지 버튼 컴포넌트 추가 (대형/소형 옵션)
  * 재료의 상세 정보를 표시하는 카드 컴포넌트 추가
  * 재료 관리 기능을 위한 카드 컴포넌트 추가 (만료 날짜 배지 포함)
  * 앱의 메인 진입점을 탭 기반 네비게이션으로 변경

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->