### PR TITLE
[FIX] 피드백 반영

### DIFF
--- a/mohaemukzip/Sources/Feature/Profile/Views/ProfileChangeView.swift
+++ b/mohaemukzip/Sources/Feature/Profile/Views/ProfileChangeView.swift
@@ -133,7 +133,9 @@ private extension ProfileChangeView {
 
                 Group {
                     if let data = selectedImageData, let uiImage = UIImage(data: data) {
-                        Image(uiImage: uiImage).resizable()
+                        Image(uiImage: uiImage)
+                            .resizable()
+                            .scaledToFill()
                     } else if
                         !viewModel.myPage.profile.profileImageUrl
                             .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
@@ -172,6 +174,7 @@ private extension ProfileChangeView {
                     }
                 }
                 .frame(width: 120, height: 120)
+                .clipped()
                 .clipShape(Circle())
 
                 ZStack {
@@ -235,13 +238,11 @@ private extension ProfileChangeView {
             .background(Color(.systemGray6))
             .clipShape(RoundedRectangle(cornerRadius: 12))
 
-            if let message = validationMessage {
-                Text(message)
-                    .font(.custom("Pretendard-Regular", size: 12))
-                    .foregroundStyle(Color.red)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 4)
-            }
+            Text(validationMessage ?? "닉네임은 한글/영문/숫자만 입력할 수 있어요")
+                .font(.custom("Pretendard-Regular", size: 12))
+                .foregroundStyle(validationMessage == nil ? Color.gray : Color.red)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 4)
         }
     }
 }
@@ -265,13 +266,20 @@ private extension ProfileChangeView {
     func validateNickname(_ value: String) -> String? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        if trimmed.isEmpty { return "닉네임은 1자 이상이어야 해" }
-        if value.count > 15 { return "닉네임은 최대 15자까지 가능해" }
-        if value.contains("  ") { return "연속 공백은 사용할 수 없어" }
+        // 0자(공백만 포함) 입력
+        if trimmed.isEmpty { return "닉네임을 1자 이상 입력해 주세요." }
+        if trimmed.count > 15 { return "닉네임은 최대 15자까지 가능해" }
 
-        let pattern = "^[가-힣A-Za-z0-9 ]+$"
+        // 공백 불가(한글/영문/숫자만)
+        if value.contains(where: { $0.isWhitespace }) {
+            return "닉네임은 한글/영문/숫자만 입력할 수 있어요"
+        }
+
+        // 한글(완성형 + 자모) / 영문 / 숫자만 허용
+        // - "ㅇ" 같은 자모도 허용하기 위해 ㄱ-ㅎ, ㅏ-ㅣ 범위를 포함
+        let pattern = "^[가-힣ㄱ-ㅎㅏ-ㅣA-Za-z0-9]+$"
         if value.range(of: pattern, options: .regularExpression) == nil {
-            return "한글, 영문, 숫자, 공백만 사용할 수 있어"
+            return "이모지 및 특수문자 입력 불가"
         }
         return nil
     }

--- a/mohaemukzip/Sources/Feature/Recipe/RecipeDetailView.swift
+++ b/mohaemukzip/Sources/Feature/Recipe/RecipeDetailView.swift
@@ -668,7 +668,7 @@ private struct RecipeStepCard: View {
 // MARK: - Preview
 
 #Preview("RecipeDetailView") {
-    NavigationStack {
+		    NavigationStack {
         RecipeDetailView(
             recipeId: 1,
             base: RecipeVideo(

--- a/mohaemukzip/Sources/Feature/Recipe/RecipeListView.swift
+++ b/mohaemukzip/Sources/Feature/Recipe/RecipeListView.swift
@@ -26,6 +26,13 @@ struct RecipeListView: View {
     /// onAppear / task 중복 실행 방지 목적
     @State private var didApplyInitialCuisine = false
 
+    /// 상세 화면 진입 중복 방지 플래그
+    /// 연타/중복 탭으로 router.push가 여러 번 호출되는 것을 막는다.
+    @State private var isPushingDetail = false
+
+    /// 중복 탭 방지용 딜레이(ms)
+    private let detailPushDelayNanoseconds: UInt64 = 250_000_000 // 0.25s
+
     // MARK: - Initializers
     /// 기본 진입
     /// 카테고리 미선택 상태로 시작
@@ -136,9 +143,21 @@ struct RecipeListView: View {
                             .contentShape(Rectangle())
                             /// 영상 카드 탭 시 상세 화면 진입
                             .onTapGesture {
+                                // ✅ 연타/중복 탭 방지
+                                guard !isPushingDetail else { return }
+                                isPushingDetail = true
+
                                 Task {
+                                    // 짧은 딜레이로 빠른 연타를 흡수
+                                    try? await Task.sleep(nanoseconds: detailPushDelayNanoseconds)
+
+                                    // 상세 데이터 준비 후 화면 전환
                                     if let detail = await viewModel.prepareDetailVideo(recipeId: video.id) {
                                         router.push(.recipeDetail(detail))
+                                        // push 이후에는 목록 화면이 사라지므로 별도 해제 불필요
+                                    } else {
+                                        // 데이터 준비 실패 시에는 다시 탭 가능하게 해제
+                                        isPushingDetail = false
                                     }
                                 }
                             }
@@ -159,6 +178,9 @@ struct RecipeListView: View {
                 }
             }
             .onAppear {
+                // ✅ 상세 화면에서 돌아오면 다시 진입 가능하도록 잠금 해제
+                isPushingDetail = false
+
                 // ✅ 상세 화면에서 뒤로가기(백버튼)로 돌아올 때마다 목록을 최신 상태로 동기화
                 // 상세 화면에서 북마크 토글 등으로 상태가 바뀌어도
                 // 목록 ViewModel(videos)이 자동 갱신되지 않기 때문에, 복귀 시 서버에서 다시 조회한다.
@@ -451,7 +473,7 @@ private struct ThumbnailView: View {
         
 }
 
-// MARK: - View Count Formatting
+// MARK: - 조회수 변환
 /// 조회수 숫자를 화면 표시용 문자열로 변환
 
 private extension Int {


### PR DESCRIPTION
TODO: - 나중에 AUTH API, Network Layer(리프레시 토큰 자동 재발급), RootView 로그인 로직 완전하게 다 작성되면, 마이페이지 뷰모델에 API provider 연결, ProfileSettingsView에  로그아웃,회원탈퇴 구현. 
## 🛠️ 작업내용
1.레시피 목록에서 상세화면 진입할 떄 두번 탭되는 경우 방지. 연타 방지 ( 시간 delay 넣기 )
2.프로필 이미지 변경시 이전화면에서도 이미지 크롭 (ProfileChangeView 도 ProfileView와 동일 이미지 크롭 메카니즘 삽입)
3.닉네임 변경시 안내 문구 변경 (조건문 Text 변경)

## 📱 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]

## 관련 이슈
- Resolved: #58 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 레시피 카드를 여러 번 빠르게 클릭할 때 화면이 중복으로 열리는 문제를 해결했습니다.
* 프로필 닉네임 검증 강화: 이모지와 특수문자를 제외하고, 한글, 영문, 숫자만 허용합니다.
* 아바타 이미지가 더 깔끔하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->