### PR TITLE
로그인,로그아웃,reissue,로그아웃,회원탈퇴 로직 구현 + 리퀴드 글래스 복원

### DIFF
--- a/mohaemukzip/Info.plist
+++ b/mohaemukzip/Info.plist
@@ -18,8 +18,6 @@
         <string>Pretendard-SemiBold.otf</string>
         <string>Pretendard-Thin.otf</string>
     </array>
-    <key>UIDesignRequiresCompatibility</key>
-    <true/>
     <key>LSApplicationQueriesSchemes</key>
     <array>
         <string>youtube</string>

--- a/mohaemukzip/Service/NetworkManager.swift
+++ b/mohaemukzip/Service/NetworkManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Moya
+import Alamofire
 
 // MARK: - 공용 BaseResposneDTO
 struct BaseResponse<T: Decodable>: Decodable {
@@ -20,13 +21,200 @@ final class NetworkManager {
     static let shared = NetworkManager()
     init() {}
 
+    private let authInterceptor = AuthInterceptor()
+
     private let plugins: [PluginType] = [
         NetworkLoggerPlugin(configuration: .init(logOptions: .verbose)),
         NetworkDebugPlugin()
     ]
 
     func makeProvider<T: TargetType>(for target: T.Type) -> MoyaProvider<T> {
-        return MoyaProvider<T>(plugins: plugins)
+        // Alamofire 레벨에서 401을 감지해 토큰 재발급 후 원 요청을 1회 재시도합니다.
+        let session = Session(interceptor: authInterceptor)
+        return MoyaProvider<T>(session: session, plugins: plugins)
+    }
+}
+
+// MARK: - 401 자동 토큰 재발급 Interceptor
+
+/// 401 응답을 감지하면 /auth/reissue 를 호출해서 토큰을 갱신한 뒤,
+/// 실패한 요청을 1회 재시도하는 Alamofire Interceptor 입니다.
+///
+/// ⚠️ 주의
+/// - 동시에 여러 요청이 401을 맞는 경우, 재발급은 1번만 수행하고 나머지 요청은 대기 후 함께 재시도합니다.
+/// - /auth/reissue 자체가 401을 맞을 때는 재시도 루프를 방지하기 위해 재발급을 시도하지 않습니다.
+private final class AuthInterceptor: RequestInterceptor {
+
+    private let lock = NSLock()
+    private var isRefreshing = false
+    private var retryCompletions: [(RetryResult) -> Void] = []
+
+    // 재발급 호출은 Interceptor가 붙지 않은 별도 Provider로 수행(무한루프 방지)
+    private let refreshProvider: MoyaProvider<AuthAPI> = {
+        // 기본 Provider는 별도의 Session을 사용하므로 현재 Interceptor(Session)과 분리됩니다.
+        MoyaProvider<AuthAPI>()
+    }()
+
+    func adapt(
+        _ urlRequest: URLRequest,
+        for session: Session,
+        completion: @escaping (Result<URLRequest, Error>) -> Void
+    ) {
+        var request = urlRequest
+
+        // 이미 Authorization이 있으면 그대로
+        if request.value(forHTTPHeaderField: "Authorization") != nil {
+            completion(.success(request))
+            return
+        }
+
+        // accessToken 없으면 건드리지 않음
+        guard !Config.accessTK.isEmpty else {
+            completion(.success(request))
+            return
+        }
+
+        // auth 관련 일부 엔드포인트는 Authorization이 불필요할 수 있어 제외
+        if let urlString = request.url?.absoluteString {
+            if urlString.contains("/auth/login") ||
+                urlString.contains("/auth/signup") ||
+                urlString.contains("/auth/check-loginid") ||
+                urlString.contains("/auth/reissue") {
+                completion(.success(request))
+                return
+            }
+        }
+
+        request.setValue("Bearer \(Config.accessTK)", forHTTPHeaderField: "Authorization")
+
+        #if DEBUG
+        if let urlString = request.url?.absoluteString {
+            let prefix = String(Config.accessTK.prefix(16))
+            print("[AuthInterceptor] adapt Authorization added | tokenPrefix=\(prefix)... url=\(urlString)")
+        }
+        #endif
+
+        completion(.success(request))
+    }
+
+    func retry(
+        _ request: Request,
+        for session: Session,
+        dueTo error: Error,
+        completion: @escaping (RetryResult) -> Void
+    ) {
+        // status code가 없으면 재시도 판단 불가
+        guard let response = request.task?.response as? HTTPURLResponse else {
+            completion(.doNotRetry)
+            return
+        }
+
+        // 401이 아니면 재시도하지 않음
+        guard response.statusCode == 401 else {
+            completion(.doNotRetry)
+            return
+        }
+
+        // reissue 요청 자체가 401이면 루프 방지
+        if let urlString = request.request?.url?.absoluteString,
+           urlString.contains("/auth/reissue") {
+            #if DEBUG
+            print("[AuthInterceptor] 401 on /auth/reissue -> doNotRetry")
+            #endif
+            completion(.doNotRetry)
+            return
+        }
+
+        // refreshToken이 없으면 재발급 불가
+        guard !Config.refreshTK.isEmpty else {
+            #if DEBUG
+            print("[AuthInterceptor] 401 but refresh token is empty -> doNotRetry")
+            #endif
+            completion(.doNotRetry)
+            return
+        }
+
+        // 동시 401 단일화: 현재 요청을 대기열에 넣고, 재발급이 진행 중이면 종료
+        lock.lock()
+        retryCompletions.append(completion)
+        let shouldStartRefresh = !isRefreshing
+        if shouldStartRefresh { isRefreshing = true }
+        lock.unlock()
+
+        if !shouldStartRefresh {
+            #if DEBUG
+            if let urlString = request.request?.url?.absoluteString {
+                print("[AuthInterceptor] 401 queued (refresh in progress) | url=\(urlString)")
+            }
+            #endif
+            return
+        }
+
+        #if DEBUG
+        let accessPrefix = String(Config.accessTK.prefix(16))
+        let refreshPrefix = String(Config.refreshTK.prefix(16))
+        print("[AuthInterceptor] 401 detected -> start reissue | access=\(accessPrefix)... refresh=\(refreshPrefix)...")
+        #endif
+
+        // 실제 재발급 수행
+        refreshProvider.request(.reissue) { [weak self] result in
+            guard let self else { return }
+
+            switch result {
+            case .success(let response):
+                do {
+                    let decoded = try response.map(ReissueResponseDTO.self)
+                    let newAccess = decoded.result.accessToken
+                    let newRefresh = decoded.result.refreshToken
+
+                    // 토큰 저장(앱 재시작 대비) + Config 동기화
+                    TokenStore.saveTokens(access: newAccess, refresh: newRefresh)
+                    Config.accessTK = newAccess
+                    Config.refreshTK = newRefresh
+
+                    #if DEBUG
+                    let newAccessPrefix = String(newAccess.prefix(16))
+                    let newRefreshPrefix = String(newRefresh.prefix(16))
+                    print("[AuthInterceptor] reissue success | newAccess=\(newAccessPrefix)... newRefresh=\(newRefreshPrefix)...")
+                    #endif
+
+                    self.finishRefreshing(with: .retry)
+
+                } catch {
+                    #if DEBUG
+                    let raw = String(data: response.data, encoding: .utf8) ?? "(binary/empty)"
+                    print("[AuthInterceptor] reissue decode fail | status=\(response.statusCode)")
+                    print("[AuthInterceptor] rawBody: \(raw)")
+                    print("[AuthInterceptor] error: \(error)")
+                    #endif
+                    self.finishRefreshing(with: .doNotRetryWithError(error))
+                }
+
+            case .failure(let error):
+                #if DEBUG
+                print("[AuthInterceptor] reissue request fail | error=\(error)")
+                if let response = error.response {
+                    let raw = String(data: response.data, encoding: .utf8) ?? "(binary/empty)"
+                    print("[AuthInterceptor] errorBody: \(raw)")
+                }
+                #endif
+                self.finishRefreshing(with: .doNotRetryWithError(error))
+            }
+        }
+    }
+
+    private func finishRefreshing(with result: RetryResult) {
+        lock.lock()
+        let completions = retryCompletions
+        retryCompletions.removeAll()
+        isRefreshing = false
+        lock.unlock()
+
+        #if DEBUG
+        print("[AuthInterceptor] finishRefreshing -> callbacks=\(completions.count) result=\(result)")
+        #endif
+
+        completions.forEach { $0(result) }
     }
 }
 

--- a/mohaemukzip/Service/Networking/Auth/AuthAPI.swift
+++ b/mohaemukzip/Service/Networking/Auth/AuthAPI.swift
@@ -13,7 +13,9 @@ enum AuthAPI {
     case signup(SignUpRequestDTO)
     case login(LoginRequestDTO)
     case checkLoginId(CheckLoginIdRequestDTO)
- 
+    case reissue
+    case logout
+    case withdrawal
 }
 
 extension AuthAPI: TargetType {
@@ -30,6 +32,12 @@ extension AuthAPI: TargetType {
             return "/auth/login"
         case .checkLoginId:
             return "/auth/check-loginid"
+        case .reissue:
+            return "/auth/reissue"
+        case .logout:
+            return "/auth/logout"
+        case .withdrawal:
+            return "/auth/withdrawal"
         }
     }
     
@@ -41,6 +49,12 @@ extension AuthAPI: TargetType {
             return .post
         case .checkLoginId:
             return .post
+        case .reissue:
+            return .post
+        case .logout:
+            return .post
+        case .withdrawal:
+            return .delete
         }
     }
     
@@ -52,16 +66,26 @@ extension AuthAPI: TargetType {
             return .requestJSONEncodable(request)
         case .checkLoginId(let request):
             return .requestJSONEncodable(request)
+        case .reissue, .logout, .withdrawal:
+            return .requestPlain
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .checkLoginId:
+        case .reissue:
+            return [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(Config.accessTK)",
+                "X-RefreshToken": "\(Config.refreshTK)"
+            ]
+
+        case .logout, .withdrawal, .checkLoginId:
             return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(Config.accessTK)"
             ]
+
         default:
             return [
                 "Content-Type": "application/json"

--- a/mohaemukzip/Service/Networking/Auth/AuthService.swift
+++ b/mohaemukzip/Service/Networking/Auth/AuthService.swift
@@ -10,6 +10,7 @@ import Foundation
 import Moya
 
 final class AuthService {
+    static let shared = AuthService()
     private let provider = NetworkManager.shared.makeProvider(for: AuthAPI.self)
 
     func signup(nickname: String, loginId: String, password: String, terms: [SignUpTermDTO]) async throws -> AuthTokensModel {
@@ -82,5 +83,58 @@ final class AuthService {
 
     func checkDuplicateId(loginId: String) async throws -> Bool {
         try await checkLoginId(loginId: loginId).available
+    }
+
+    // MARK: - Token Reissue
+
+    /// AccessToken 만료 등으로 401 발생 시 사용
+    /// - Returns: 새로 발급된 (accessToken, refreshToken)
+    func reissue() async throws -> (accessToken: String, refreshToken: String) {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(.reissue) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decoded = try response.map(ReissueResponseDTO.self)
+                        continuation.resume(returning: (decoded.result.accessToken, decoded.result.refreshToken))
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    // MARK: - Logout
+
+    func logout() async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(.logout) { result in
+                switch result {
+                case .success:
+                    continuation.resume(returning: ())
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    // MARK: - Withdrawal
+
+    func withdrawal() async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(.withdrawal) { result in
+                switch result {
+                case .success:
+                    continuation.resume(returning: ())
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 }

--- a/mohaemukzip/Service/Networking/Auth/koh'sDTO.swift
+++ b/mohaemukzip/Service/Networking/Auth/koh'sDTO.swift
@@ -1,0 +1,38 @@
+//
+//  koh'sDTO.swift
+//  mohaemukzip
+//
+//  Created by 고석현 on 2/8/26.
+//
+
+import Foundation
+
+// MARK: - Auth: Reissue
+
+struct ReissueResponseDTO: Decodable {
+    let isSuccess: Bool
+    let code: String
+    let message: String
+    let result: ReissueResultDTO
+}
+
+struct ReissueResultDTO: Decodable {
+    let accessToken: String
+    let refreshToken: String
+}
+
+// MARK: - Auth: Logout / Withdrawal
+
+struct LogoutResponseDTO: Decodable {
+    let isSuccess: Bool
+    let code: String
+    let message: String
+    let result: EmptyResult?
+}
+
+struct WithdrawalResponseDTO: Decodable {
+    let isSuccess: Bool
+    let code: String
+    let message: String
+    let result: EmptyResult?
+}

--- a/mohaemukzip/Sources/Feature/Main/RootView.swift
+++ b/mohaemukzip/Sources/Feature/Main/RootView.swift
@@ -24,10 +24,8 @@ final class AppState: ObservableObject {
 
     /// 앱 시작 시 토큰 확인 후 루트 결정
     func boot() {
-        
         // Splash 를 먼저 보여주고, 토큰 로딩 후 루트를 결정
         root = .splash
-        TokenStore.clear() // << 자동로그인 제거용
         Task { @MainActor in
             // 스플래시가 너무 빨리 사라져서 안 보이는 문제 방지 (필요 시 시간 조절)
             try? await Task.sleep(nanoseconds: 1500_000_000)
@@ -42,7 +40,28 @@ final class AppState: ObservableObject {
             Config.accessTK = accessToken ?? ""
             Config.refreshTK = refreshToken ?? ""
 
-            root = (accessToken == nil) ? .auth : .main
+            // accessToken이 있으면 바로 메인
+            if let accessToken, !accessToken.isEmpty {
+                root = .main
+                return
+            }
+
+            // accessToken이 없고 refreshToken만 있으면 1회 재발급 시도
+            if let refreshToken, !refreshToken.isEmpty {
+                print("[AppState] boot -> accessToken nil, try reissue")
+                do {
+                    let tokens = try await AuthService.shared.reissue()
+                    loginSucceeded(accessToken: tokens.accessToken, refreshToken: tokens.refreshToken)
+                    print("[AppState] boot -> reissue success, go main")
+                } catch {
+                    print("[AppState] boot -> reissue fail, go auth | error=\(error)")
+                    clearSession(reason: "boot reissue fail")
+                }
+                return
+            }
+
+            // 둘 다 없으면 인증 루트
+            root = .auth
         }
     }
 
@@ -54,20 +73,57 @@ final class AppState: ObservableObject {
         Config.accessTK = accessToken
         Config.refreshTK = refreshToken ?? ""
 
+        print("[AppState] loginSucceeded -> save tokens & go main")
         root = .main
     }
-    
-// 로그아웃 미구현
-//    func logout() {
-//        TokenStore.clear()
-//        accessToken = nil
-//        refreshToken = nil
-//
-//        Config.accessTK = nil
-//        Config.refreshTK = nil
-//
-//        root = .auth
-//    }
+
+
+    // MARK: - Session Control
+
+    /// 토큰/루트 전환을 한 곳에서 처리
+    @MainActor
+    private func clearSession(reason: String) {
+        print("[AppState] clearSession | reason=\(reason)")
+
+        TokenStore.clear()
+        accessToken = nil
+        refreshToken = nil
+
+        Config.accessTK = ""
+        Config.refreshTK = ""
+
+        root = .auth
+    }
+
+    /// 마이페이지 로그아웃 버튼에서 호출할 예정
+    @MainActor
+    func logout() async {
+        print("[AppState] logout -> start")
+        do {
+            try await AuthService.shared.logout()
+            print("[AppState] logout -> api success")
+            clearSession(reason: "logout")
+        } catch {
+            // 서버가 이미 세션을 만료/차단한 경우에도 로컬은 안전하게 정리
+            print("[AppState] logout -> api fail, clear local anyway | error=\(error)")
+            clearSession(reason: "logout api fail")
+        }
+    }
+
+    /// 마이페이지 회원탈퇴 버튼에서 호출할 예정
+    @MainActor
+    func withdrawal() async {
+        print("[AppState] withdrawal -> start")
+        do {
+            try await AuthService.shared.withdrawal()
+            print("[AppState] withdrawal -> api success")
+            clearSession(reason: "withdrawal")
+        } catch {
+            // 탈퇴 API 실패여도 토큰이 꼬였을 수 있으니 로컬은 정리
+            print("[AppState] withdrawal -> api fail, clear local anyway | error=\(error)")
+            clearSession(reason: "withdrawal api fail")
+        }
+    }
 }
 
 // MARK: - Token Store (임시: UserDefaults)

--- a/mohaemukzip/Sources/Feature/Profile/Views/ProfileSettingsView.swift
+++ b/mohaemukzip/Sources/Feature/Profile/Views/ProfileSettingsView.swift
@@ -14,6 +14,12 @@ struct ProfileSettingsView: View {
 
     @Environment(NavigationRouter.self) private var router
 
+    @EnvironmentObject private var appState: AppState
+
+    @State private var isPerformingAuthAction: Bool = false
+    @State private var showLogoutConfirm: Bool = false
+    @State private var showWithdrawalConfirm: Bool = false
+
     private let appVersionText: String = {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
@@ -46,6 +52,34 @@ struct ProfileSettingsView: View {
             }
         }
         .navigationBarHidden(true)
+        .alert("로그아웃", isPresented: $showLogoutConfirm) {
+            Button("취소", role: .cancel) {}
+            Button("로그아웃", role: .destructive) {
+                Task { @MainActor in
+                    isPerformingAuthAction = true
+                    defer { isPerformingAuthAction = false }
+
+                    print("[ProfileSettingsView] logout -> confirm")
+                    await appState.logout()
+                }
+            }
+        } message: {
+            Text("정말 로그아웃할까요?")
+        }
+        .alert("회원탈퇴", isPresented: $showWithdrawalConfirm) {
+            Button("취소", role: .cancel) {}
+            Button("회원탈퇴", role: .destructive) {
+                Task { @MainActor in
+                    isPerformingAuthAction = true
+                    defer { isPerformingAuthAction = false }
+
+                    print("[ProfileSettingsView] withdrawal -> confirm")
+                    await appState.withdrawal()
+                }
+            }
+        } message: {
+            Text("탈퇴하면 계정 정보가 삭제될 수 있어요. 계속할까요?")
+        }
     }
 
     private var header: some View {
@@ -97,13 +131,21 @@ struct ProfileSettingsView: View {
     private var actionSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             settingsRow(title: "로그아웃", showsChevron: false) {
-                print("[ProfileSettingsView] 로그아웃")
+                guard !isPerformingAuthAction else {
+                    print("[ProfileSettingsView] logout ignored (busy)")
+                    return
+                }
+                showLogoutConfirm = true
             }
 
        
 
             settingsRow(title: "회원탈퇴", showsChevron: false, titleColor: .black) {
-                print("[ProfileSettingsView] 회원탈퇴")
+                guard !isPerformingAuthAction else {
+                    print("[ProfileSettingsView] withdrawal ignored (busy)")
+                    return
+                }
+                showWithdrawalConfirm = true
             }
 
             Text(appVersionText)
@@ -145,6 +187,7 @@ struct ProfileSettingsView: View {
             .padding(.vertical, 14)
             .contentShape(Rectangle())
         }
+        .disabled(isPerformingAuthAction)
         .buttonStyle(.plain)
     }
 }
@@ -152,9 +195,11 @@ struct ProfileSettingsView: View {
 
 #Preview {
     let router = NavigationRouter()
+    let appState = AppState()
 
     NavigationStack {
         ProfileSettingsView()
     }
     .environment(router)
+    .environmentObject(appState)
 }


### PR DESCRIPTION

## 🛠️ 작업내용
- [x] 리퀴드 글래스 복원(iOS 가산점) -> 하단 탭뷰. (리퀴드 글래스 하나라도 쓰이면 가산점 5점 다 준대요) 
- [x] 전반적인 로그인 로직 구현 (회원가입/로그인 -> 로그아웃,회원탈퇴) 
- [x] 스웨거로 이중확인하기 위해 테스트 했을떄 모두 작동하는거 확인
- [x] Network Manager 토큰관리  로직 수정
-  [x] AuthAPI 수정, AuthService 수정, RootView 수정
- [x] koh'sDTO 작성(토큰재발급,회원탈퇴,로그아웃 ->이거 3개 한파일에 작성하는게 나을 것 같아서 했는데 이름 뭐로 지을지 몰라서 일단 이름 저렇게)  (나중에 수정 예정)



## 📱 스크린샷
카톡방에 영상 남길게요 ! 

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]

## 관련 이슈
- Resolved: #61 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 세션 만료 시 자동 토큰 갱신 기능 추가
  * 로그아웃 기능 추가 (확인 대화상자 포함)
  * 계정 탈퇴 기능 추가 (확인 대화상자 포함)
  * 앱 시작 시 세션 복구 로직 개선으로 사용자 경험 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->