### PR TITLE
[Feat] 회원가입 시 이용약관 및 개인정보처리방침 노션 페이지 연결

### DIFF
--- a/mohaemukzip/Sources/Common/Components/SafariView.swift
+++ b/mohaemukzip/Sources/Common/Components/SafariView.swift
@@ -1,0 +1,19 @@
+//
+//  SafariView.swift
+//  mohaemukzip
+//
+//  Created by 이한결 on 6/26/26.
+//
+
+import SwiftUI
+import SafariServices
+
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+    
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+    
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) { }
+}

--- a/mohaemukzip/Sources/Feature/Onboarding/Views/AgreeView.swift
+++ b/mohaemukzip/Sources/Feature/Onboarding/Views/AgreeView.swift
@@ -6,6 +6,9 @@ struct AgreeView: View {
     @EnvironmentObject private var router: AuthRouter
     @State private var viewModel = AgreeViewModel()
     
+    // 선택된 TermsPage
+    @State private var selectedTermsPage: TermsPage?
+    
     var body: some View {
         VStack(spacing: 0) {
             topBar
@@ -21,7 +24,8 @@ struct AgreeView: View {
                     AgreeCheckRow(
                         title: "모두 동의",
                         isChecked: $viewModel.isAllAgree,
-                        onToggle: { viewModel.toggleAllAgree() }
+                        onToggle: { viewModel.toggleAllAgree() },
+                        onTitleTap: nil
                     )
                     .padding(.bottom, 6)
                     
@@ -32,25 +36,29 @@ struct AgreeView: View {
                         AgreeCheckRow(
                             title: "만 14세 이상입니다. (필수)",
                             isChecked: $viewModel.isOver14,
-                            onToggle: { viewModel.toggleOver14() }
+                            onToggle: { viewModel.toggleOver14() },
+                            onTitleTap: nil
                         )
                         
                         AgreeCheckRow(
                             title: "서비스 이용약관에 동의 (필수)",
                             isChecked: $viewModel.isServiceAgree,
-                            onToggle: { viewModel.toggleServiceAgree() }
+                            onToggle: { viewModel.toggleServiceAgree() },
+                            onTitleTap: { selectedTermsPage = .service }
                         )
                         
                         AgreeCheckRow(
                             title: "개인정보 수집 및 이용에 동의 (필수)",
                             isChecked: $viewModel.isPrivacyAgree,
-                            onToggle: { viewModel.togglePrivacyAgree() }
+                            onToggle: { viewModel.togglePrivacyAgree() },
+                            onTitleTap: { selectedTermsPage = .privacy }
                         )
                         
                         AgreeCheckRow(
                             title: "광고 및 마케팅 수신에 동의 (선택)",
                             isChecked: $viewModel.isMarketingAgree,
-                            onToggle: { viewModel.toggleMarketingAgree() }
+                            onToggle: { viewModel.toggleMarketingAgree() },
+                            onTitleTap: { selectedTermsPage = .marketing }
                         )
                     }
                 }
@@ -63,6 +71,11 @@ struct AgreeView: View {
             bottomButton
         }
         .navigationBarBackButtonHidden(true)
+        // selectedTermsPage가 바뀌면 사파리 페이지 열기
+        // SafariView에 url은 TermsPage 열거형에 정의해둔 notion page url 연결
+        .sheet(item: $selectedTermsPage) { page in
+            SafariView(url: page.url)
+        }
     }
     
     private var topBar: some View {
@@ -100,30 +113,58 @@ struct AgreeView: View {
     }
 }
 
+private enum TermsPage: Identifiable {
+    case service // 서비스 이용 약관
+    case privacy // 개인정보처리방침
+    case marketing // 광고 및 마케팅 정보 수신 동의
+
+    var id: Self { self }
+
+    var url: URL {
+        switch self {
+        case .service:
+            return URL(string: "https://skillful-freighter-e74.notion.site/38b7472452f9806e946cc3aa2b5e721d?source=copy_link")!
+        case .privacy:
+            return URL(string: "https://skillful-freighter-e74.notion.site/38b7472452f98094a4a6d796b3180bd6?source=copy_link")!
+        case .marketing:
+            return URL(string: "https://skillful-freighter-e74.notion.site/38b7472452f980e38cdde8fc450049b4?source=copy_link")!
+        }
+    }
+}
+
 private struct AgreeCheckRow: View {
     let title: String
     @Binding var isChecked: Bool
     let onToggle: () -> Void
+    let onTitleTap: (() -> Void)?
     
     var body: some View {
-        Button {
-            onToggle()
-        } label: {
-            HStack(spacing: 12) {
+        HStack(spacing: 12) {
+            Button {
+                onToggle()
+            } label: {
                 Image(systemName: "checkmark.circle.fill")
                     .resizable()
                     .frame(width: 22, height: 22)
                     .foregroundStyle(isChecked ? Color.main400 : Color.grey300)
-                
-                Text(title)
-                    .font(.PretendardRegular16)
-                    .foregroundStyle(Color.black)
-                
-                Spacer()
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
+            }.buttonStyle(.plain)
+            
+            Button {
+                if let onTitleTap {
+                    onTitleTap()
+                } else {
+                    onToggle()
+                }
+            } label: {
+                    Text(title)
+                        .underline(onTitleTap != nil)
+                        .font(.PretendardRegular16)
+                        .foregroundStyle(Color.black)
+            }.buttonStyle(.plain)
+            
+            Spacer()
         }
-        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
     }
 }


### PR DESCRIPTION
## ✨ PR 유형 Feat 

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
[ 회원가입 흐름에서 서비스 이용약관, 개인정보처리방침, 광고 및 마케팅 정보 수신 동의 텍스트 클릭 시 노션 페이지로 연결. ]

## 📱 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## 📌 리뷰 포인트
[  ]

## 관련 이슈
- Resolved: #92 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 온보딩 약관 동의 화면에서 약관 제목을 탭하면 해당 약관 내용을 바로 열 수 있게 되었습니다.
  * 앱 내에서 외부 웹페이지를 표시하는 보기 방식이 추가되었습니다.

* **Bug Fixes**
  * 약관 항목별로 제목 탭 동작과 체크 동작이 분리되어, 의도한 항목만 열리도록 개선했습니다.
  * 전체 동의나 연령 확인 항목은 제목 탭으로 이동하지 않도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->