### PR TITLE
[Design] QA 관련 디자인 요소 반영

### DIFF
--- a/mohaemukzip/Sources/Common/Components/IngredientManagementCard/BottomSheets/IngredientAdditionBottomSheet.swift
+++ b/mohaemukzip/Sources/Common/Components/IngredientManagementCard/BottomSheets/IngredientAdditionBottomSheet.swift
@@ -87,7 +87,7 @@ struct IngredientFormBottomSheet: View {
                     Spacer()
                 }.padding(.bottom, 6)
                 
-                VStack(spacing: 1) {
+                VStack(spacing: 0) {
                     Button ( action: {
                         withAnimation(.easeInOut(duration: 0.3)) {
                             showStorageCase.toggle()
@@ -95,8 +95,7 @@ struct IngredientFormBottomSheet: View {
                     }) {
                         ZStack {
                             RoundedRectangle(cornerRadius: 4)
-                                .stroke(lineWidth: 1)
-                                .foregroundStyle(showStorageCase ? .main400 : .grey300)
+                                .strokeBorder(showStorageCase ? .main400 : .grey300, lineWidth: 1)
                                 .frame(height: 45)
                             HStack {
                                 Text(formValue.storage.displayName)
@@ -112,30 +111,32 @@ struct IngredientFormBottomSheet: View {
                     }
                     
                     if (showStorageCase) {
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 4)
-                                .stroke(lineWidth: 1)
-                                .foregroundStyle(.grey300)
-                                .frame(height: 159)
-                            VStack(spacing: 0) {
-                                ForEach(StorageType.allCases, id: \.self) { type in
-                                    ZStack {
-                                        RoundedRectangle(cornerRadius: 4)
-                                            .frame(height: 53)
-                                            .foregroundStyle(formValue.storage == type ? .main100 : .clear)
-                                        Button( action: {formValue.storage = type;
-                                            withAnimation(.easeInOut(duration: 0.3)) { showStorageCase.toggle() } } ) {
-                                                HStack {
-                                                    Text(type.displayName)
-                                                        .font(.PretendardRegular16)
-                                                        .foregroundStyle(.grey900)
-                                                        .padding(.leading, 10)
-                                                    Spacer()
-                                                }
-                                        }
+                        VStack(spacing: 0) {
+                            ForEach(StorageType.allCases, id: \.self) { type in
+                                Button {
+                                    formValue.storage = type
+                                    withAnimation(.easeInOut(duration: 0.3)) {
+                                        showStorageCase.toggle()
                                     }
+                                } label: {
+                                    HStack {
+                                        Text(type.displayName)
+                                            .font(.PretendardRegular16)
+                                            .foregroundStyle(.grey900)
+                                            .padding(.leading, 10)
+
+                                        Spacer()
+                                    }
+                                    .frame(height: 53)
+                                    .background(formValue.storage == type ? .main100 : .clear)
                                 }
                             }
+                        }
+                        .frame(height: 159)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 4)
+                                .strokeBorder(.grey300, lineWidth: 1)
                         }
                     }
                 }.padding(.bottom, 16) // end of VStack
@@ -172,7 +173,7 @@ struct IngredientFormBottomSheet: View {
                     } } ) {
                         ZStack {
                             RoundedRectangle(cornerRadius: 4)
-                                .stroke(.main400, lineWidth: 1)
+                                .strokeBorder(.main400, lineWidth: 1)
                             Text("자동 추천일")
                                 .font(.PretendardRegular16)
                                 .foregroundStyle(.main400)

--- a/mohaemukzip/Sources/Common/Components/IngredientManagementCard/Fridge/IngredientBox.swift
+++ b/mohaemukzip/Sources/Common/Components/IngredientManagementCard/Fridge/IngredientBox.swift
@@ -37,7 +37,7 @@ struct IngredientBox: View {
                         .foregroundStyle(.grey700)
                     Spacer()
                     Button(action: { withAnimation { isExpanded.toggle() } } ) {
-                        Image(isExpanded ? "icon-chevron-down" : "icon-chevron-up")
+                        Image(isExpanded ? "icon-chevron-up" : "icon-chevron-down")
                             .foregroundStyle(.grey700)
                     }
                 }

--- a/mohaemukzip/Sources/Common/Components/IngredientManagementCard/RecentSearch/RecentSearch.swift
+++ b/mohaemukzip/Sources/Common/Components/IngredientManagementCard/RecentSearch/RecentSearch.swift
@@ -9,8 +9,7 @@ struct RecentSearch: View {
         Button ( action: { onTap() } ) {
             ZStack {
                 RoundedRectangle(cornerRadius: 30)
-                    .stroke(lineWidth: 1)
-                    .foregroundStyle(.grey300)
+                    .strokeBorder(.grey300, lineWidth: 1)
                     .frame(height: 32)
                 
                 HStack {

--- a/mohaemukzip/Sources/Feature/Ingredient/IngredientSearch/Views/IngredientDetailSearchView.swift
+++ b/mohaemukzip/Sources/Feature/Ingredient/IngredientSearch/Views/IngredientDetailSearchView.swift
@@ -23,7 +23,7 @@ struct IngredientDetailSearchView: View {
                             .frame(height: 44)
                             .foregroundStyle(.grey100)
                         
-                        
+
                         HStack {
                             TextField("재료명을 입력하세요.", text: $viewModel.searchText)
                                 .font(.PretendardRegular16)

--- a/mohaemukzip/Sources/Feature/Ingredient/IngredientSearch/Views/IngredientDetailSearchView.swift
+++ b/mohaemukzip/Sources/Feature/Ingredient/IngredientSearch/Views/IngredientDetailSearchView.swift
@@ -61,6 +61,8 @@ struct IngredientDetailSearchView: View {
                                                                  Task { await viewModel.deleteRecent(name: ingredient.keyword) } })
                                     }
                                 }
+                                .padding(.horizontal, 1)
+                                .padding(.vertical, 1)
                             }.padding(.vertical, 16)
                         }
                         

--- a/mohaemukzip/Sources/Feature/Onboarding/ViewModels/SignupViewModel.swift
+++ b/mohaemukzip/Sources/Feature/Onboarding/ViewModels/SignupViewModel.swift
@@ -158,11 +158,13 @@ final class SignupViewModel {
     }
     
     func onChangePassword(_ newValue: String) {
+        errorMessage = nil
         model.password = newValue
         validatePasswordMatch()
     }
 
     func onChangePasswordConfirm(_ newValue: String) {
+        errorMessage = nil
         model.passwordConfirm = newValue
         validatePasswordMatch()
     }

--- a/mohaemukzip/Sources/Feature/Onboarding/Views/SignupView.swift
+++ b/mohaemukzip/Sources/Feature/Onboarding/Views/SignupView.swift
@@ -16,6 +16,9 @@ struct SignupView: View {
                 header
                 nicknameSection
                 emailSection
+                if viewModel.shouldShowVerificationField {
+                    verificationCodeSection
+                }
                 passwordSection
                 passwordConfirmSection
                 
@@ -58,7 +61,7 @@ struct SignupView: View {
     }
     
     private var nicknameSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             Text("닉네임")
                 .font(.PretendardMedium14)
                 .foregroundStyle(.grey700)
@@ -93,7 +96,7 @@ struct SignupView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text("이메일")
                 .font(.PretendardMedium14)
-                .foregroundStyle(.grey600)
+                .foregroundStyle(.grey700)
             
             HStack(spacing: 10) {
                 TextField("이메일을 입력해주세요.", text: Binding(
@@ -132,9 +135,6 @@ struct SignupView: View {
             
             emailStatusMessage
             
-            if viewModel.shouldShowVerificationField {
-                verificationCodeSection
-            }
         }
     }
     
@@ -189,9 +189,9 @@ struct SignupView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text("인증번호")
                 .font(.PretendardMedium14)
-                .foregroundStyle(.grey600)
+                .foregroundStyle(.grey700)
             
-            HStack(spacing: 6) {
+            HStack(spacing: 10) {
                 HStack {
                     TextField(
                         "인증번호 6자리 입력",
@@ -250,6 +250,7 @@ struct SignupView: View {
             }
         }
     }
+    
     
     @ViewBuilder
     private var verificationStatusMessage: some View {
@@ -325,10 +326,10 @@ struct SignupView: View {
     }
     
     private var passwordConfirmSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             Text("비밀번호 확인")
-                .font(.PretendardRegular16)
-                .foregroundStyle(.grey600)
+                .font(.PretendardMedium14)
+                .foregroundStyle(.grey700)
             
             ZStack(alignment: .leading) {
                 RoundedRectangle(cornerRadius: 10)


### PR DESCRIPTION
## ✨ PR 유형 Design

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
[ 디자인 QA에 맞춰 냉장고/재료 검색/회원가입 화면의 여백, 잘림, 폰트 스타일을 조정했습니다. ]

- 재료 추가 바텀시트의 좌우 여백과 드롭다운 테두리/선택 배경 표시를 정리했습니다.
- 최근 검색어 칩의 미세한 잘림을 줄이고 가로 스크롤 여백을 조정했습니다.
- 회원가입 화면의 입력 섹션 간격, 인증번호 위치, 라벨 스타일을 디자인 기준에 맞게 조정했습니다.
- 회원가입 실패 메시지는 비밀번호 입력 수정 시 초기화되도록 보강했습니다.

## 📱 스크린샷
| 기능 | 스크린샷 |
|:--:|:--:|
| GIF | <img src = "" width ="250"> |

## 📌 리뷰 포인트
[ 재료 추가 바텀시트 드롭다운 테두리/선택 배경, 최근 검색어 칩 잘림 여부, 회원가입 화면의 간격과 실패 메시지 표시 위치 확인 부탁드립니다. ]

## ✅ 확인사항
- Xcode BuildProject 성공

## 관련 이슈
- Resolved: #110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 보관 장소 선택 목록을 버튼형 행으로 개선하고 간격, 테두리, 모서리 표시를 조정했습니다.
  - 냉장고 보관함의 펼침·접힘 상태에 맞는 화살표가 표시됩니다.
  - 최근 검색어 및 재료 검색 화면의 테두리와 여백을 개선했습니다.
  - 회원가입 화면의 이메일 인증번호 입력 영역과 섹션 간격을 정리했습니다.
  - 비밀번호 입력 시 기존 오류 메시지가 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->